### PR TITLE
Improve auth security and logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,8 @@ auth:
 
 ### file
 Credentials are read from a flat file containing `user:password` pairs, one per
-line.
+line. The password value can be stored in plain text or as a hash generated with
+`password_hash`. Hashed values are checked with `password_verify`.
 
 ```yaml
 auth:
@@ -41,6 +42,7 @@ auth:
     - file
   file:
     path: /path/to/passwd.txt
+    # each line: "user:password" where password may be a hash
 ```
 
 ### imap


### PR DESCRIPTION
## Summary
- support hashed passwords in file authentication
- log authentication attempts with context
- regenerate session ID on successful login
- document hashed password usage

## Testing
- `php -l public/index.php`
- `php -l lib/yaml.php`


------
https://chatgpt.com/codex/tasks/task_e_687e5907a378832c8fce948b8ee51537