### PR TITLE
Refine AJAX polling with jQuery

### DIFF
--- a/config/global.yml
+++ b/config/global.yml
@@ -9,3 +9,8 @@ data:
 interface_config_dir: config/interfaces
 
 db_path: data/wakeonstorage.sqlite
+
+# Refresh interval (seconds) for AJAX calls (seconds)
+ajax:
+  refresh: 10          # general polling interval
+  router_refresh: 10   # router status refresh interval

--- a/config/interfaces/exampledemo.yml
+++ b/config/interfaces/exampledemo.yml
@@ -10,6 +10,19 @@ auth:
     - uniq
   uniq:
     password_hash: "$2y$12$zdqst7kiZMBwnAIrbUm2IeT6mRpk5IPVcObWgaNkeGDOQK6oScQrm" # hashed with PHP password_hash
+# Router configuration example
+router:
+  router_check:
+    methode: ping
+    host: 192.168.1.1
+    count: 1
+  router_up:
+    - "09:00"
+    - "12:00"
+
+ajax:
+  refresh: 10
+  router_refresh: 10
 #  file:
 #    path: /path/to/passwd.txt     # lines formatted "user:password"
 #  imap:

--- a/public/api.php
+++ b/public/api.php
@@ -1,0 +1,46 @@
+<?php
+require_once __DIR__ . '/../vendor/autoload.php';
+
+use Symfony\Component\Yaml\Yaml;
+use WakeOnStorage\Router;
+
+$global = Yaml::parseFile(__DIR__ . '/../config/global.yml');
+$host = $_SERVER['HTTP_HOST'] ?? 'default';
+$host = preg_replace('/:\d+$/', '', $host);
+$configDir = __DIR__ . '/../' . ($global['interface_config_dir'] ?? 'config/interfaces');
+$file = "$configDir/{$host}.yml";
+if (!file_exists($file)) {
+    $file = "$configDir/exampledemo.yml";
+}
+$cfg = Yaml::parseFile($file);
+
+$now = time();
+$routerSince = isset($_GET['router_since']) ? (int)$_GET['router_since'] : 0;
+$routerRefresh = (int)($global['ajax']['router_refresh'] ?? 10);
+
+$result = ['timestamp' => $now];
+
+if ($now - $routerSince >= $routerRefresh) {
+    $routerAvailable = true;
+    $nextRouter = null;
+    if (!empty($cfg['router']['router_check'])) {
+        $rc = $cfg['router']['router_check'];
+        if (($rc['methode'] ?? '') === 'ping') {
+            $hostCheck = $rc['host'] ?? 'localhost';
+            $count = (int)($rc['count'] ?? 1);
+            $routerAvailable = Router::ping($hostCheck, $count);
+        }
+    }
+    if (!$routerAvailable) {
+        $nextRouter = Router::nextSchedule($cfg['router']['router_up'] ?? []);
+    }
+    $result['router'] = [
+        'available' => $routerAvailable,
+        'next' => $nextRouter,
+    ];
+    $result['router_timestamp'] = $now;
+}
+
+header('Content-Type: application/json');
+echo json_encode($result);
+

--- a/src/Router.php
+++ b/src/Router.php
@@ -1,0 +1,42 @@
+<?php
+namespace WakeOnStorage;
+
+class Router
+{
+    public static function ping(string $host, int $count = 1): bool
+    {
+        if (!$host) {
+            return false;
+        }
+        $cmd = sprintf('ping -c %d %s 2>&1', $count, escapeshellarg($host));
+        exec($cmd, $out, $code);
+        return $code === 0;
+    }
+
+    public static function nextSchedule(array $times): ?string
+    {
+        if (!$times) {
+            return null;
+        }
+        $now = time();
+        $today = date('Y-m-d ');
+        $next = null;
+        foreach ($times as $t) {
+            $ts = strtotime($today . $t);
+            if ($ts === false) {
+                continue;
+            }
+            if ($ts > $now) {
+                $next = $ts;
+                break;
+            }
+        }
+        if ($next === null) {
+            $ts = strtotime('+1 day ' . $times[0]);
+            if ($ts !== false) {
+                $next = $ts;
+            }
+        }
+        return $next ? date('H:i', $next) : null;
+    }
+}


### PR DESCRIPTION
## Summary
- expand `ajax` options in global and interface configs
- update `api.php` to accept last poll timestamp and refresh router status based on config
- switch to jQuery in `index.php` and poll backend using timestamps

## Testing
- `php -l public/index.php`
- `php -l public/api.php`
- `php -l src/Router.php`
- `composer install` *(fails: CONNECT tunnel failed)*

------
https://chatgpt.com/codex/tasks/task_e_687e8b976188832ca2b95b5707e06c63