### PR TITLE
Implement API data retrieval with caching

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,24 @@ Global settings are stored in `config/global.yml`. Per-domain configurations are
 located in `config/interfaces/`. Only files prefixed with `example` are tracked
 in Git to avoid leaking secrets.
 
+## Data sources
+
+`public/api.php` exposes various data points used by the interfaces. Each source
+is configured under the `data` section of `config/global.yml` with a refresh
+interval declared in `ajax:`. Responses are cached in the SQLite database.
+
+Available sources:
+
+- **batterie** – current battery level read from Home&nbsp;Assistant.
+- **production_solaire** – live solar production value from Home&nbsp;Assistant.
+- **production_solaire_estimation** – forecast from Solcast. Only the portion
+  between now and the next sunset is returned. If the request happens at night,
+  the period between the next sunrise and sunset is used instead.
+
+Each entry defines the API URL, bearer token and cache lifetime (TTL). When the
+cache is older than the TTL the API is queried again; otherwise the stored value
+is returned.
+
 ## Running
 Use PHP's built-in server for local testing:
 

--- a/config/global.yml
+++ b/config/global.yml
@@ -3,8 +3,21 @@ contact_admin:
   email: admin@example.com
 
 data:
-  production_solaire_api: http://example.com/solar
-  battery_api: http://example.com/battery
+  batterie:
+    - url: http://wakeonstorage-local.retzo.net:8123/api/states/sensor.batterie1
+      token: eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiI0ZmE0Mzc5ODIxMzM0ZTk4OGQ0N2ZjMDQwMWI3OTNlNCIsImlhdCI6MTc1MjQ5NjcwOSwiZXhwIjoyMDY3ODU2NzA5fQ.GUxMTdSwtngTW0ZbOTBxSYAHpBp_6ewQl6am11MSvYk
+      ttl: 600        # cache lifetime in seconds
+      type: home_assistant
+  production_solaire:
+    url: http://homeassistant-local.retzo.net:8123/api/states/sensor.puissance_corrigee_2
+    token: eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiI0ZmE0Mzc5ODIxMzM0ZTk4OGQ0N2ZjMDQwMWI3OTNlNCIsImlhdCI6MTc1MjQ5NjcwOSwiZXhwIjoyMDY3ODU2NzA5fQ.GUxMTdSwtngTW0ZbOTBxSYAHpBp_6ewQl6am11MSvYk
+    ttl: 600
+    type: home_assistant
+  production_solaire_estimation:
+    url: https://api.solcast.com.au/rooftop_sites/264a-d2d7-20d7-66e5/forecasts?format=json
+    token: WchAGalywMgBjtdubPqAA3ScVwCXTEPr
+    ttl: 10800
+    type: solcast
 
 interface_config_dir: config/interfaces
 
@@ -14,3 +27,6 @@ db_path: data/wakeonstorage.sqlite
 ajax:
   refresh: 10          # general polling interval
   router_refresh: 10   # router status refresh interval
+  batterie_refresh: 600
+  production_solaire_refresh: 600
+  production_solaire_estimation_refresh: 1800

--- a/public/api.php
+++ b/public/api.php
@@ -4,6 +4,37 @@ require_once __DIR__ . '/../vendor/autoload.php';
 use Symfony\Component\Yaml\Yaml;
 use WakeOnStorage\Router;
 
+function http_get_json(string $url, array $headers = [], int $timeout = 5): ?array {
+    $opts = [
+        'http' => [
+            'method' => 'GET',
+            'header' => implode("\r\n", $headers),
+            'timeout' => $timeout,
+        ],
+    ];
+    $context = stream_context_create($opts);
+    $res = @file_get_contents($url, false, $context);
+    if ($res === false) {
+        return null;
+    }
+    return json_decode($res, true);
+}
+
+function cache_fetch(PDO $pdo, string $key, callable $callback, int $ttl): ?array {
+    $stmt = $pdo->prepare('SELECT value, updated_at FROM data_cache WHERE key=?');
+    $stmt->execute([$key]);
+    $row = $stmt->fetch(PDO::FETCH_ASSOC);
+    if ($row && time() - (int)$row['updated_at'] < $ttl) {
+        return json_decode($row['value'], true);
+    }
+    $data = $callback();
+    if ($data !== null) {
+        $stmt = $pdo->prepare('REPLACE INTO data_cache (key, value, updated_at) VALUES (?,?,?)');
+        $stmt->execute([$key, json_encode($data), time()]);
+    }
+    return $data;
+}
+
 $global = Yaml::parseFile(__DIR__ . '/../config/global.yml');
 $host = $_SERVER['HTTP_HOST'] ?? 'default';
 $host = preg_replace('/:\d+$/', '', $host);
@@ -14,9 +45,21 @@ if (!file_exists($file)) {
 }
 $cfg = Yaml::parseFile($file);
 
+$dbRelative = $global['db_path'] ?? 'data/wakeonstorage.sqlite';
+$dbPath = realpath(__DIR__ . '/..') . '/' . ltrim($dbRelative, '/');
+$pdo = new PDO('sqlite:' . $dbPath);
+$pdo->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
+$pdo->exec("CREATE TABLE IF NOT EXISTS data_cache (key TEXT PRIMARY KEY, value TEXT, updated_at INTEGER)");
+
 $now = time();
 $routerSince = isset($_GET['router_since']) ? (int)$_GET['router_since'] : 0;
 $routerRefresh = (int)($global['ajax']['router_refresh'] ?? 10);
+$batterySince = isset($_GET['battery_since']) ? (int)$_GET['battery_since'] : 0;
+$batteryRefresh = (int)($global['ajax']['batterie_refresh'] ?? 600);
+$solarSince = isset($_GET['solar_since']) ? (int)$_GET['solar_since'] : 0;
+$solarRefresh = (int)($global['ajax']['production_solaire_refresh'] ?? 600);
+$forecastSince = isset($_GET['forecast_since']) ? (int)$_GET['forecast_since'] : 0;
+$forecastRefresh = (int)($global['ajax']['production_solaire_estimation_refresh'] ?? 1800);
 
 $result = ['timestamp' => $now];
 
@@ -40,6 +83,88 @@ if ($now - $routerSince >= $routerRefresh) {
         'next' => $nextRouter,
     ];
     $result['router_timestamp'] = $now;
+}
+
+if ($now - $batterySince >= $batteryRefresh && !empty($global['data']['batterie'][0])) {
+    $cfgBat = $global['data']['batterie'][0];
+    $ttl = (int)($cfgBat['ttl'] ?? 0);
+    $data = cache_fetch($pdo, 'batterie0', function() use ($cfgBat) {
+        $headers = ['Content-Type: application/json'];
+        if (!empty($cfgBat['token'])) {
+            $headers[] = 'Authorization: Bearer ' . $cfgBat['token'];
+        }
+        return http_get_json($cfgBat['url'], $headers);
+    }, $ttl);
+    $value = $data['state'] ?? null;
+    $result['batterie'] = [$value !== null ? $value : 'NA'];
+    $result['battery_timestamp'] = $now;
+}
+
+if ($now - $solarSince >= $solarRefresh && !empty($global['data']['production_solaire'])) {
+    $cfgSolar = $global['data']['production_solaire'];
+    $ttl = (int)($cfgSolar['ttl'] ?? 0);
+    $data = cache_fetch($pdo, 'production_solaire', function() use ($cfgSolar) {
+        $headers = ['Content-Type: application/json'];
+        if (!empty($cfgSolar['token'])) {
+            $headers[] = 'Authorization: Bearer ' . $cfgSolar['token'];
+        }
+        return http_get_json($cfgSolar['url'], $headers);
+    }, $ttl);
+    $value = $data['state'] ?? null;
+    $result['production_solaire'] = $value !== null ? $value : 'NA';
+    $result['solar_timestamp'] = $now;
+}
+
+if ($now - $forecastSince >= $forecastRefresh && !empty($global['data']['production_solaire_estimation'])) {
+    $cfgFor = $global['data']['production_solaire_estimation'];
+    $ttl = (int)($cfgFor['ttl'] ?? 0);
+    $raw = cache_fetch($pdo, 'production_solaire_estimation', function() use ($cfgFor) {
+        $headers = ['Content-Type: application/json'];
+        if (!empty($cfgFor['token'])) {
+            $headers[] = 'Authorization: Bearer ' . $cfgFor['token'];
+        }
+        return http_get_json($cfgFor['url'], $headers);
+    }, $ttl);
+    $forecast = [];
+    if ($raw && !empty($raw['forecasts'])) {
+        $nowTs = time();
+        $start = null;
+        foreach ($raw['forecasts'] as $f) {
+            $ts = strtotime($f['period_end'] ?? '');
+            $val = $f['pv_estimate'] ?? 0;
+            if ($ts === false) continue;
+            if ($start === null) {
+                if ($ts >= $nowTs && $val > 0) {
+                    $start = true;
+                } else {
+                    continue;
+                }
+            }
+            if ($start && $val <= 0 && $ts > $nowTs) {
+                break;
+            }
+            if ($start) {
+                if ($ts >= $nowTs) {
+                    $forecast[] = ['period_end' => $f['period_end'], 'pv_estimate' => $val];
+                }
+            }
+        }
+        if (!$forecast) {
+            $start = false;
+            foreach ($raw['forecasts'] as $f) {
+                $ts = strtotime($f['period_end'] ?? '');
+                $val = $f['pv_estimate'] ?? 0;
+                if ($ts === false) continue;
+                if (!$start && $val > 0) { $start = true; }
+                if ($start) {
+                    $forecast[] = ['period_end' => $f['period_end'], 'pv_estimate' => $val];
+                    if ($val <= 0 && count($forecast) > 1) break;
+                }
+            }
+        }
+    }
+    $result['production_solaire_estimation'] = $forecast ?: 'NA';
+    $result['forecast_timestamp'] = $now;
 }
 
 header('Content-Type: application/json');

--- a/public/index.php
+++ b/public/index.php
@@ -174,6 +174,9 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST' && isset($_POST['schedule_router'])) {
 <script>
 var refreshInterval = <?= $refresh ?> * 1000;
 var routerSince = 0;
+var batterySince = 0;
+var solarSince = 0;
+var forecastSince = 0;
 
 function notify(type, text, life) {
   var cls = type === 'warn' ? 'warning' : 'info';
@@ -191,7 +194,12 @@ if (typeof initialMessage !== 'undefined') {
 var routerNote = null;
 
 function updateAll() {
-  $.getJSON('api.php', { router_since: routerSince }, function(data) {
+  $.getJSON('api.php', {
+      router_since: routerSince,
+      battery_since: batterySince,
+      solar_since: solarSince,
+      forecast_since: forecastSince
+  }, function(data) {
     if (data.router_timestamp) {
       routerSince = data.router_timestamp;
     }
@@ -213,7 +221,12 @@ function updateAll() {
         plan.addClass('d-none');
         actions.removeClass('d-none');
       }
-    }
+    if (data.battery_timestamp) { batterySince = data.battery_timestamp; }
+    if (data.solar_timestamp) { solarSince = data.solar_timestamp; }
+    if (data.forecast_timestamp) { forecastSince = data.forecast_timestamp; }
+    if (data.batterie) console.log('batterie', data.batterie);
+    if (data.production_solaire) console.log('prod', data.production_solaire);
+    if (data.production_solaire_estimation) console.log('forecast', data.production_solaire_estimation);
   }).always(function() {
     setTimeout(updateAll, refreshInterval);
   });


### PR DESCRIPTION
## Summary
- add battery, solar production and forecast endpoints to `global.yml`
- document data sources and caching in README
- extend `public/api.php` to fetch remote values and store them in SQLite
- update index page javascript to query new API fields

## Testing
- `composer validate --no-check-all --strict`
- `php -l public/api.php`
- `php -l public/index.php`


------
https://chatgpt.com/codex/tasks/task_e_687eb1594a7c832cb5f143cd4ae4319e